### PR TITLE
Add support for Tsuru Java platform

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
+export PATH=/usr/lib/jvm/java-8-oracle/bin:$PATH
+mvn package

--- a/tsuru.yaml
+++ b/tsuru.yaml
@@ -1,0 +1,4 @@
+hooks:
+  build:
+     - ./build.sh
+


### PR DESCRIPTION
This commit adds two files to create a build hook for tsuru java platform.

These changes allow the Tsuru Java platform to build the java project inside the platform. Deploying
the built jar (built using maven) can also be used as a deployment process. This is documented
in the Ops manual.
